### PR TITLE
Add Multiple PDF changes

### DIFF
--- a/backend/src/upload_trigger/main.py
+++ b/backend/src/upload_trigger/main.py
@@ -6,11 +6,14 @@ import PyPDF2
 import shortuuid
 import urllib
 from aws_lambda_powertools import Logger
+from zipfile import ZipFile
 
 DOCUMENT_TABLE = os.environ["DOCUMENT_TABLE"]
 MEMORY_TABLE = os.environ["MEMORY_TABLE"]
 QUEUE = os.environ["QUEUE"]
 BUCKET = os.environ["BUCKET"]
+
+EXTRACTION_PATH = "/tmp/extracted_files"
 
 ddb = boto3.resource("dynamodb")
 document_table = ddb.Table(DOCUMENT_TABLE)
@@ -18,6 +21,13 @@ memory_table = ddb.Table(MEMORY_TABLE)
 sqs = boto3.client("sqs")
 s3 = boto3.client("s3")
 logger = Logger()
+
+def extract_zip_file(zip_file_path, extraction_path=EXTRACTION_PATH):
+    """Extract PDF files from a ZIP and return their paths"""
+    with ZipFile(zip_file_path, 'r') as zip_ref:
+        zip_ref.extractall(extraction_path)
+    pdf_files = [os.path.join(extraction_path, f) for f in os.listdir(extraction_path) if f.endswith('.pdf')]
+    return pdf_files
 
 @logger.inject_lambda_context(log_event=True)
 def lambda_handler(event, context):
@@ -33,9 +43,23 @@ def lambda_handler(event, context):
 
             s3.download_file(BUCKET, key, temp_file_path)
 
-            with open(temp_file_path, "rb") as f:
+            """ with open(temp_file_path, "rb") as f:
                 reader = PyPDF2.PdfReader(f)
-                pages = str(len(reader.pages))
+                pages = str(len(reader.pages)) """
+
+            if file_name.endswith('.zip'):
+                # Handle ZIP file by extracting PDFs
+                extracted_files = extract_zip_file(temp_file_path)
+                pages = 0
+                for pdf_path in extracted_files:
+                    with open(pdf_path, "rb") as f:
+                        reader = PyPDF2.PdfReader(f)
+                        pages += len(reader.pages)
+            else:
+                # Handle single PDF
+                with open(temp_file_path, "rb") as f:
+                    reader = PyPDF2.PdfReader(f)
+                    pages = str(len(reader.pages))
 
             conversation_id = shortuuid.uuid()
             timestamp = datetime.utcnow()

--- a/frontend/src/components/DocumentUploader.tsx
+++ b/frontend/src/components/DocumentUploader.tsx
@@ -16,11 +16,17 @@ const DocumentUploader: React.FC<DocumentUploaderProps> = ({ onDocumentUploaded 
   const [inputStatus, setInputStatus] = useState<string>("idle");
   const [buttonStatus, setButtonStatus] = useState<string>("ready");
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [isFolder, setIsFolder] = useState<boolean>(false); // New state to determine if the uploaded file is a folder (ZIP)
 
   useEffect(() => {
     if (selectedFile) {
-      if (selectedFile.type === "application/pdf") {
+      if (selectedFile.type === "application/pdf" || selectedFile.type === "application/zip") { // Added support for ZIP files along with PDFs
         setInputStatus("valid");
+        if (selectedFile.type === "application/zip") {
+          setIsFolder(true); // Mark as folder if it's a ZIP file
+        } else {
+          setIsFolder(false);
+        }
       } else {
         setSelectedFile(null);
       }
@@ -49,7 +55,7 @@ const DocumentUploader: React.FC<DocumentUploaderProps> = ({ onDocumentUploaded 
       fetch(presignedUrl?.presignedurl, {
         method: "PUT",
         body: selectedFile,
-        headers: { "Content-Type": "application/pdf" },
+        headers: { "Content-Type": selectedFile.type }, // Update content type for ZIP and PDF
       }).then(() => {
         setButtonStatus("success");
         if (onDocumentUploaded) onDocumentUploaded();
@@ -65,7 +71,9 @@ const DocumentUploader: React.FC<DocumentUploaderProps> = ({ onDocumentUploaded 
 
   return (
     <div>
-      <h2 className="text-2xl font-bold pb-4">Add document</h2>
+      <h2 className="text-2xl font-bold pb-4">
+        {isFolder ? "Add project folder (ZIP)" : "Add document"} {/* Updated heading to indicate folder upload */}
+      </h2>
       {inputStatus === "idle" && (
         <div className="flex items-center justify-center w-full">
           <label
@@ -74,14 +82,11 @@ const DocumentUploader: React.FC<DocumentUploaderProps> = ({ onDocumentUploaded 
           >
             <div className="flex flex-col items-center justify-center pt-5 pb-6">
               <CloudArrowUpIcon className="w-12 h-12 mb-3 text-gray-400" />
-
               <p className="mb-2 text-sm text-gray-500">
-                <span className="font-semibold">Click to upload</span> your
-                document
+                <span className="font-semibold">Click to upload</span> your document (PDF or ZIP)  {/* Updated instructions to mention ZIP support */}
               </p>
-              <p className="text-xs text-gray-500">Only .pdf accepted</p>
+              <p className="text-xs text-gray-500">Only .pdf or .zip accepted</p>  {/* Updated file types allowed */}
             </div>
-
             <input
               onChange={handleFileChange}
               id="dropzone-file"
@@ -174,7 +179,6 @@ const DocumentUploader: React.FC<DocumentUploaderProps> = ({ onDocumentUploaded 
                   </button>
                 )}
                 {buttonStatus === "success" && (
-
                   <button
                     disabled
                     onClick={uploadFile}
@@ -183,9 +187,7 @@ const DocumentUploader: React.FC<DocumentUploaderProps> = ({ onDocumentUploaded 
                   >
                     <CheckCircleIcon className="w-5 h-5 mr-1.5" />
                     Upload successful!
-
                   </button>
-
                 )}
               </div>
             </>


### PR DESCRIPTION
backend/upload_trigger/main.py:
- Added handling for ZIP uploads, allowing extraction of PDF files for processing.
- Modified metadata extraction to calculate total pages from multiple PDFs within a ZIP.

backend/generate_embeddings/main.py:
- Updated embedding generation to support both individual PDFs and multiple PDFs from ZIP files.
- Refactored to ensure accurate page number tracking for documents in a ZIP.

frontend/src/components/DocumentUploader.tsx:
- Added support for uploading ZIP files.
- Modified the user interface to indicate when users are uploading a ZIP (folder) or a single PDF.